### PR TITLE
Add in service identification through environment variables.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,40 @@ ADD . /opt/app-root/src/
 
 EXPOSE 8080
 
-CMD /bin/bash -c 'npm start'
+# Variables that define default values for the OpenShift Project
+# and the Openshift dynamic subdomain that is being used. These 
+# values are used to build up the service URLs that are used for
+# the services at runtime. These can also be overridden by injecting
+# environment variables into the container at runtime.
+ENV OS_SUBDOMAIN='rhel-cdk.10.1.2.2.xip.io' \
+    OS_PROJECT='helloworld-msa'
+
+# The CMD. We do the following here:
+#  - Process the env vars. All of them can be overriden at run time
+#    so we need to run them through some logic on container bringup.
+#  - Inject some env vars into the services.json.
+#  - Inject some env vars into index.html
+#  - Start the server via npm start.
+CMD HELLOURL=${HELLOURL:-"http://hello-${OS_PROJECT}.${OS_SUBDOMAIN}/api/hello"} \
+        HELLOCHAINURL=${HELLOCHAINURL:-"http://hello-${OS_PROJECT}.${OS_SUBDOMAIN}/api/hello-chaining"} \
+        HOLAURL=${HOLAURL:-"http://hola-${OS_PROJECT}.${OS_SUBDOMAIN}/api/hola"}           \
+        BONJOURURL=${BONJOURURL:-"http://bonjour-${OS_PROJECT}.${OS_SUBDOMAIN}/api/bonjour"}  \
+        ALOHAURL=${ALOHAURL:-"http://aloha-${OS_PROJECT}.${OS_SUBDOMAIN}/api/aloha"}        \
+        OLAURL=${OLAURL:-"http://ola-${OS_PROJECT}.${OS_SUBDOMAIN}/api/ola"}              \
+        NAMASTEURL=${NAMASTEURL:-"http://namaste-${OS_PROJECT}.${OS_SUBDOMAIN}/api/namaste"}  \
+        APIGATEWAYURL=${APIGATEWAYURL:-"http://api-gateway-${OS_PROJECT}.${OS_SUBDOMAIN}/api"}   \
+        HYSTRIXDASHBOARDURL=${HYSTRIXDASHBOARDURL:-"http://hystrix-dashboard-${OS_PROJECT}.${OS_SUBDOMAIN}"} \
+        ZIPKINQUERYURL=${ZIPKINQUERYURL:-"http://zipkin-query-${OS_PROJECT}.${OS_SUBDOMAIN}"} \
+    && sed -i.orig services.json \
+        -e 's|HELLOURL|'"$HELLOURL"'|' \
+        -e 's|HELLOCHAINURL|'"$HELLOCHAINURL"'|' \
+        -e 's|HOLAURL|'"$HOLAURL"'|' \
+        -e 's|BONJOURURL|'"$BONJOURURL"'|' \
+        -e 's|ALOHAURL|'"$ALOHAURL"'|' \
+        -e 's|OLAURL|'"$OLAURL"'|' \
+        -e 's|NAMASTEURL|'"$NAMASTEURL"'|' \
+        -e 's|APIGATEWAYURL|'"$APIGATEWAYURL"'|' \
+    && sed -i.orig index.html \
+        -e 's|HYSTRIXDASHBOARDURL|'"$HYSTRIXDASHBOARDURL"'|' \
+        -e 's|ZIPKINQUERYURL|'"$ZIPKINQUERYURL"'|' \
+    && /bin/bash -c 'npm start'

--- a/index.html
+++ b/index.html
@@ -195,13 +195,13 @@
 			<!--  Tab Hystrix Dashaboard -->
 			<div role="tabpanel" class="tab-pane active" id="hystrix">
 				<iframe style="padding-top: 5vh; border: 0; width: 100%; height: 80vh; position: inherit;" id="hystrix-dashboard-iframe"
-					src="http://hystrix-dashboard-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/monitor/monitor.html?stream=http%3A%2F%2Fturbine-server%2Fturbine.stream"> </iframe>
+					src="HYSTRIXDASHBOARDURL/monitor/monitor.html?stream=http%3A%2F%2Fturbine-server%2Fturbine.stream"> </iframe>
 			</div>
 
 			<!--  Tab Hystrix Dashaboard -->
 			<div role="tabpanel" class="tab-pane active" id="zipkin">
 				<iframe style="padding-top: 5vh; border: 0; width: 100%; height: 80vh; position: inherit;" id="zipkin-dashboard-iframe"
-					src="http://zipkin-query-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/"> </iframe>
+					src="ZIPKINQUERYURL"> </iframe>
 			</div>
 		</div>
 	</div>

--- a/services.json
+++ b/services.json
@@ -1,26 +1,26 @@
 {
   "hello-service": {
-    "url": "http://hello-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/hello"
+    "url": "HELLOURL"
   },
   "hello-chaining": {
-      "url": "http://hello-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/hello-chaining"
-    },
+      "url": "HELLOCHAINURL"
+  },
   "hola-service": {
-    "url": "http://hola-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/hola"
+    "url": "HOLAURL"
   },
   "bonjour-service": {
-    "url": "http://bonjour-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/bonjour"
+    "url": "BONJOURURL"
   },
   "aloha-service": {
-    "url": "http://aloha-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/aloha"
+    "url": "ALOHAURL"
   },
   "ola-service": {
-    "url": "http://ola-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/ola"
+    "url": "OLAURL"
   },
   "namaste-service": {
-    "url": "http://namaste-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api/namaste"
+    "url": "NAMASTEURL"
   },
   "api-gateway": {
-    "url": "http://api-gateway-helloworld-msa.rhel-cdk.10.1.2.2.xip.io/api"
+    "url": "APIGATEWAYURL"
   }
 }


### PR DESCRIPTION
You can now completely override the url endpoints for the services
by providing environment variables at runtime. You can either directly
override the service urls with these env vars:
- HELLOURL
- HELLOCHAINURL
- HOLAURL
- BONJOURURL
- ALOHAURL
- OLAURL
- NAMASTEURL
- APIGATEWAYURL
- HYSTRIXDASHBOARDURL
- ZIPKINQUERYURL

or you can override the openshify dynamic subdomain or project name
by providing these env vars at runtime:
- OS_SUBDOMAIN
- OS_PROJECT
