### PR TITLE
hystrix and zipkin views shouldn't be active on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
 
 			<!--  Tab Hystrix Dashaboard -->
 			{{#hystrix}}
-			<div role="tabpanel" class="tab-pane active" id="hystrix">
+			<div role="tabpanel" class="tab-pane" id="hystrix">
 				<iframe style="padding-top: 5vh; border: 0; width: 100%; height: 80vh; position: inherit;"
 					id="hystrix-dashboard-iframe"
 					src="HYSTRIXDASHBOARDURL/monitor/monitor.html?stream=http%3A%2F%2Fturbine-server%2Fturbine.stream"> </iframe>
@@ -253,7 +253,7 @@
 
 			<!--  Tab Zipkin Dashaboard -->
 			{{#zipkin}}
-			<div role="tabpanel" class="tab-pane active" id="zipkin">
+			<div role="tabpanel" class="tab-pane" id="zipkin">
 				<iframe style="padding-top: 5vh; border: 0; width: 100%; height: 80vh; position: inherit;"
 					id="zipkin-dashboard-iframe" src="ZIPKINQUERYURL"> </iframe>
 			</div>


### PR DESCRIPTION
i noticed that on the first page load, that the hystrix and/or the zipkin view section shows up underneath the SSO section.  but when actually using the navigation tabs, they don't show up.

Looks like they were always active until the user navigates.