### PR TITLE
Update docker image to our new official community version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ryanj/centos7-nodejs:6.4.0
+FROM bucharestgold/centos7-nodejs:6.9.5
 
 EXPOSE 8080
 
 # Variables that define default values for the OpenShift Project
-# and the Openshift dynamic subdomain that is being used. These 
+# and the Openshift dynamic subdomain that is being used. These
 # values are used to build up the service URLs that are used for
 # the services at runtime. These can also be overridden by injecting
 # environment variables into the container at runtime.


### PR DESCRIPTION
We(the node team) have taken ownership of the community s2i images that ryan previously had created, Now that we have publish them under our new org on dockerhub, this updates the image being used.