### PR TITLE
Update Dockerfile to always pull latest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bucharestgold/centos7-nodejs:7.7.4
+FROM bucharestgold/centos7-nodejs:latest
 
 EXPOSE 8080
 


### PR DESCRIPTION
No need to pin to a specific node release